### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Kevin Mark <kmark937@gmail.com>
 maintainer=Kevin Mark <kmark937@gmail.com>
 sentence=The simple DigiMesh XBee library for Arduino
 paragraph=Because it doesn't need to be that hard.
+category=Communication
 url=https://github.com/kmark/Bee
 architectures=*


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library Bee is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7. If you prefer a different category I'm happy to change it to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
